### PR TITLE
Tweak side nav placement style

### DIFF
--- a/projects/cashmere/src/lib/sidenav/sidenav.component.scss
+++ b/projects/cashmere/src/lib/sidenav/sidenav.component.scss
@@ -4,6 +4,9 @@
     height: 100%;
     padding: 0;
     width: 200px;
+    position: absolute;
+    top: 0;
+    bottom: 0;
 
     .sidenav-brand {
         background-color: $wcf-red;


### PR DESCRIPTION
Currently the side nav is causing the main content to come below it instead of being off to the right. This will keep the side nav pulled to the left and covering the entire left column while allowing the main content to be nicely aligned off to the right.