### PR TITLE
fix: icon within button link is no longer underlined

### DIFF
--- a/projects/cashmere/src/lib/sass/button.scss
+++ b/projects/cashmere/src/lib/sass/button.scss
@@ -154,6 +154,10 @@ $btn-icon-sz: 18px;
     box-shadow: none;
     text-decoration: underline;
 
+    .hc-icon:before {
+        display: inline-block;
+    }
+
     .label {
         color: $gray-500;
         font-weight: 400;


### PR DESCRIPTION
WCASHMERE-45: Fixed an issue where an icon within a button link would be underlined with the rest of
the text.