### PR TITLE
fix: wcashmere23 input example update

### DIFF
--- a/projects/cashmere-examples/src/lib/input-suffix/input-suffix-example.component.html
+++ b/projects/cashmere-examples/src/lib/input-suffix/input-suffix-example.component.html
@@ -1,11 +1,11 @@
 <hc-form-field inline="true">
-    <hc-label>Minimum Value:</hc-label>
+    <hc-label>Min:</hc-label>
     <input hcInput placeholder="0-100" class="demo-input">
-    <hc-icon hcSuffix fontSet="fa" fontIcon="fa-thermometer-0"></hc-icon>
+    <hc-icon hcSuffix fontSet="fa" fontIcon="fa-user-circle"></hc-icon>
 </hc-form-field>
 
 <hc-form-field inline="true">
-    <hc-label>Maximum Value:</hc-label>
+    <hc-label>Max:</hc-label>
     <input hcInput placeholder="100-500" class="demo-input">
-    <hc-icon hcSuffix fontSet="fa" fontIcon="fa-thermometer-full"></hc-icon>
+    <hc-icon hcSuffix fontSet="fa" fontIcon="fa-user-circle"></hc-icon>
 </hc-form-field>

--- a/projects/cashmere/src/lib/sass/_mixins.scss
+++ b/projects/cashmere/src/lib/sass/_mixins.scss
@@ -48,6 +48,6 @@
 }
 @mixin formFieldFocusedState() {
     box-shadow: 0 0 5px $blue-glow;
-    border: 1px solid $blue-glow;
+    //border: 1px solid $blue-glow;
     outline: none;
 }

--- a/projects/cashmere/src/lib/sass/_mixins.scss
+++ b/projects/cashmere/src/lib/sass/_mixins.scss
@@ -48,6 +48,5 @@
 }
 @mixin formFieldFocusedState() {
     box-shadow: 0 0 5px $blue-glow;
-    //border: 1px solid $blue-glow;
     outline: none;
 }

--- a/projects/cashmere/src/lib/sass/form-field.scss
+++ b/projects/cashmere/src/lib/sass/form-field.scss
@@ -67,15 +67,10 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     border-radius: 1px;
 
     background: $white;
-
-    //@include formFieldFocusTransition();
 }
 
 @mixin hc-form-field-input-focused() {
     @include formFieldFocusedState();
-    // &:not(.hc-form-field-invalid) {
-    //     padding: 0.5px;
-    // }
 }
 
 @mixin hc-form-field-disabled-flex() {
@@ -128,7 +123,6 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     min-width: $mat-form-field-default-infix-width;
     line-height: 1.357em; //19px
     padding: $infix-padding 10px 0.714em;
-    //height: $field-height;
 }
 
 @mixin hc-form-field-label-wrapper() {

--- a/projects/cashmere/src/lib/sass/form-field.scss
+++ b/projects/cashmere/src/lib/sass/form-field.scss
@@ -10,7 +10,7 @@ $infix-margin-top: 1.143em * $line-height * $label-font-scale;
 $prefix-suffix-icon-font-size: 125%;
 $field-height: 2.85rem;
 
-$infix-padding: 0.572em; //was 0.4em
+$infix-padding: 0.786em; //was 0.4em
 $error-margin-top: 0.4em / $error-font-scale;
 $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 
@@ -68,14 +68,14 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 
     background: $white;
 
-    @include formFieldFocusTransition();
+    //@include formFieldFocusTransition();
 }
 
 @mixin hc-form-field-input-focused() {
     @include formFieldFocusedState();
-    &:not(.hc-form-field-invalid) {
-        padding: 0.5px;
-    }
+    // &:not(.hc-form-field-invalid) {
+    //     padding: 0.5px;
+    // }
 }
 
 @mixin hc-form-field-disabled-flex() {
@@ -126,7 +126,8 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
     position: relative;
     flex: auto;
     min-width: $mat-form-field-default-infix-width;
-    padding: $infix-padding 10px;
+    line-height: 1.357em; //19px
+    padding: $infix-padding 10px 0.714em;
     //height: $field-height;
 }
 
@@ -143,7 +144,7 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 }
 
 @mixin hc-form-field-label-wrapper-inline() {
-    padding: 7px 15px 0 0;
+    padding: 10px 15px 0 0;
 }
 
 @mixin hc-form-field-label-wrapper-icon() {
@@ -175,7 +176,7 @@ $wrapper-padding-bottom: ($error-margin-top + $line-height) * $error-font-scale;
 
 @mixin hc-form-field-label-inline() {
     font: inherit;
-    font-size: calculateRem(14px);
+    font-size: calculateRem(16px);
     color: $gray-500;
     pointer-events: none; // We shouldn't catch mouse events (let them through).
 


### PR DESCRIPTION
- Swapped input suffix icons to the user icon. 
- Adjusted labels to be aligned with field text. 
- Adjusted form field text to be properly aligned. 
- All input borders are gray-50. 
- Removed a transition animation that had been placed on the input suffix