### PR TITLE
fix(datepicker): WCASHMERE-53: Datepicker today button fixed

### DIFF
--- a/projects/cashmere/src/lib/datepicker/calendar/calendar.component.ts
+++ b/projects/cashmere/src/lib/datepicker/calendar/calendar.component.ts
@@ -122,8 +122,8 @@ export class CalendarHeaderComponent {
 
     todayEnabled(): boolean {
         return (
-            (!this.calendar.minDate || this._dateAdapter.compareDate(this._dateAdapter.today(), this.calendar.minDate) < 0) &&
-            (!this.calendar.maxDate || this._dateAdapter.compareDate(this._dateAdapter.today(), this.calendar.maxDate) > 0)
+            (!this.calendar.minDate || this._dateAdapter.compareDate(this._dateAdapter.today(), this.calendar.minDate) > 0) &&
+            (!this.calendar.maxDate || this._dateAdapter.compareDate(this._dateAdapter.today(), this.calendar.maxDate) < 0)
         );
     }
 


### PR DESCRIPTION
When providing a mix or max date value to the datepicker component, the "today" button is now only disabled if today falls before the min date or after the max date.