### PR TITLE
feat(typeahead): add debounce and configurable spinner

### DIFF
--- a/projects/cashmere-examples/src/lib/typeahead-fetch/item.ts
+++ b/projects/cashmere-examples/src/lib/typeahead-fetch/item.ts
@@ -1,0 +1,4 @@
+export declare class Item {
+    name: string;
+    type: string;
+}

--- a/projects/cashmere-examples/src/lib/typeahead-fetch/search.service.ts
+++ b/projects/cashmere-examples/src/lib/typeahead-fetch/search.service.ts
@@ -1,0 +1,30 @@
+import {Injectable} from '@angular/core';
+import {HttpClient, HttpHeaders} from '@angular/common/http';
+import {BehaviorSubject, Observable} from 'rxjs';
+import {delay, tap} from 'rxjs/operators';
+
+@Injectable({providedIn: 'root'})
+export class SearchService {
+    private httpOptions = {
+        headers: new HttpHeaders({'Content-Type': 'application/json', 'Accept': 'application/json'})
+    };
+
+    private dataUrl = 'https://demo.dataverse.org/api/search?q=';
+
+    private itemsSubject = new BehaviorSubject<any>(null);
+    public items = this.itemsSubject.asObservable();
+
+    constructor(private http: HttpClient) {
+    }
+
+    search(term: string): Observable<any> {
+        return this.http.get<any>(this.dataUrl + term, this.httpOptions)
+            .pipe(delay(500)) // simulate a slower network since this API is so fast
+            .pipe(
+                tap(response => {
+                    this.itemsSubject.next(response.data.items);
+                    console.log(`fetched items for ${term}`);
+                })
+            );
+    }
+}

--- a/projects/cashmere-examples/src/lib/typeahead-fetch/typeahead-fetch-example.component.html
+++ b/projects/cashmere-examples/src/lib/typeahead-fetch/typeahead-fetch-example.component.html
@@ -1,4 +1,6 @@
 <div class="example-content">
+    <p>This example fetches its data from a remote API. It also makes use of the typeahead spinner to show that the search is in
+        progress.</p>
     <form [formGroup]="form">
         <hc-form-field [inline]="true">
             <hc-label>States:</hc-label>

--- a/projects/cashmere-examples/src/lib/typeahead-fetch/typeahead-fetch-example.component.html
+++ b/projects/cashmere-examples/src/lib/typeahead-fetch/typeahead-fetch-example.component.html
@@ -1,0 +1,15 @@
+<div class="example-content">
+    <form [formGroup]="form">
+        <hc-form-field [inline]="true">
+            <hc-label>States:</hc-label>
+            <hc-typeahead formControlName="item" (valueChange)="filterData($event)" (optionSelected)="optionSelected($event)"
+                          [showSpinner]="showSpinner">
+                <hc-typeahead-item *ngFor="let item of filteredData" [value]="item">
+                    {{formatItem(item)}}
+                </hc-typeahead-item>
+            </hc-typeahead>
+        </hc-form-field>
+    </form>
+
+    <pre *ngIf="selectedItem">{{selectedItem | json}}</pre>
+</div>

--- a/projects/cashmere-examples/src/lib/typeahead-fetch/typeahead-fetch-example.component.scss
+++ b/projects/cashmere-examples/src/lib/typeahead-fetch/typeahead-fetch-example.component.scss
@@ -1,0 +1,11 @@
+.example-content {
+    min-height: 240px;
+}
+
+.example-content form {
+    width: 300px;
+}
+
+pre {
+    overflow-x: hidden;
+}

--- a/projects/cashmere-examples/src/lib/typeahead-fetch/typeahead-fetch-example.component.ts
+++ b/projects/cashmere-examples/src/lib/typeahead-fetch/typeahead-fetch-example.component.ts
@@ -1,0 +1,55 @@
+import {Component, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup} from '@angular/forms';
+import {SearchService} from './search.service';
+import {Item} from './item';
+
+@Component({
+    selector: 'hc-typeahead-fetch-example',
+    templateUrl: './typeahead-fetch-example.component.html',
+    styleUrls: ['./typeahead-fetch-example.component.scss']
+})
+export class TypeaheadFetchExampleComponent implements OnInit {
+
+    form: FormGroup;
+    filteredData: Item[] = [];
+    selectedItem: Item;
+    showSpinner: boolean = false;
+
+    constructor(private fb: FormBuilder, private searchService: SearchService) {
+    }
+
+    ngOnInit(): void {
+        this.form = this.fb.group({
+            item: ['']
+        });
+    }
+
+    filterData(term) {
+        this.setValue(term);
+        if (term) {
+            this.showSpinner = true;
+            this.searchService.search(term).subscribe(items => {
+                this.filteredData = items.data.items;
+                this.showSpinner = false;
+            });
+        } else {
+            this.filteredData = [];
+        }
+    }
+
+    optionSelected(item: Item) {
+        this.selectedItem = item;
+        this.setValue(this.formatItem(item));
+    }
+
+    formatItem(item: Item): any {
+        return item ? item.name : '';
+    }
+
+    private setValue(item: Item) {
+        const control = this.form.get('item');
+        if (control) {
+            control.setValue(item);
+        }
+    }
+}

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.html
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.html
@@ -2,11 +2,12 @@
     <hc-form-field [inline]="true">
         <input #input hcInput [formControl]="_searchTerm" (keydown.tab)="_handleTabKey($event)" (keydown.enter)="_stopPropogation($event)"
                (keydown.arrowup)="_stopPropogation($event)" (keydown.arrowdown)="_stopPropogation($event)"
-               (keyup)="_filterData($event)" [placeholder]="placeholder" autocomplete="off" [title]="_value" (blur)="_blurHandler($event)"/>
+               [placeholder]="placeholder" autocomplete="off" [title]="_value" (blur)="_blurHandler($event)"/>
         <hc-error style="display: none;">parent is showing error message</hc-error>
     </hc-form-field>
 
-    <hc-icon fontSet="fa" fontIcon="fa-search" class="search" hcIconSm></hc-icon>
+    <hc-icon *ngIf="!showSpinner" fontSet="fa" fontIcon="fa-search" class="search" hcIconSm></hc-icon>
+    <hc-progress-spinner *ngIf="showSpinner" class="search-spinner" diameter="8" color="gray" [isCentered]="true"></hc-progress-spinner>
     <div class="toggle-button" #toggle>
         <hc-icon fontSet="fa" fontIcon="fa-chevron-down" class="show-all" hcIconSm (click)="_toggleShowResults()"></hc-icon>
     </div>

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.scss
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.scss
@@ -6,7 +6,7 @@ hc-typeahead {
 
 .highlight {
     font-weight: bold;
-  }
+}
 
 .typeahead-container {
     position: relative;
@@ -43,6 +43,12 @@ hc-typeahead {
         color: $gray-30;
     }
 
+    .search-spinner {
+        position: absolute;
+        top: 20px;
+        left: 15px;
+    }
+
     .hc-form-field-wrapper {
         width: calc(100% - 15px);
     }
@@ -74,6 +80,7 @@ hc-typeahead {
         width: 100%;
     }
 }
+
 .toggle-button {
     position: absolute;
     right: 0;
@@ -84,6 +91,7 @@ hc-typeahead {
     -webkit-transform: rotate(0deg);
     transform: rotate(0deg)
 }
+
 .flip-around {
     -webkit-transform: rotate(180deg);
     transform: rotate(180deg);

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.ts
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.ts
@@ -22,7 +22,8 @@ import {TypeaheadItemComponent} from './typeahead-item/typeahead-item.component'
 import {HcFormControlComponent} from '../form-field/hc-form-control.component';
 import {parseBooleanAttribute} from '../util';
 import {DOCUMENT} from '@angular/common';
-import {Subscription} from 'rxjs';
+import {fromEvent, Subscription} from 'rxjs';
+import {debounceTime, distinctUntilChanged, map} from 'rxjs/operators';
 
 @Component({
     selector: 'hc-typeahead',
@@ -51,6 +52,14 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
     /** Placeholder text for the input box of the typeahead */
     @Input()
     placeholder = '';
+
+    /** DebounceTime is the amount of time to delay between keystrokes before emitting the valueChange event for the input */
+    @Input()
+    debounceTime: number = 500;
+
+    /** Toggle to show and hide the searching filter to give user feedback */
+    @Input()
+    showSpinner: boolean = false;
 
     /** Event emitted after each key stroke in the typeahead box (after minChars requirement has been met) */
     @Output()
@@ -100,6 +109,17 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
         this._searchTerm = new FormControl(this._value);
         this._resultPanelHidden = true;
         document.body.addEventListener('click', this.handleClick.bind(this));
+
+        // add subscription and debouncer for value changing in input field
+        fromEvent(this._inputRef.nativeElement, 'keyup').pipe(
+            map((event: any) => {
+                return event.target.value;
+            }),
+            debounceTime(this.debounceTime),
+            distinctUntilChanged()
+        ).subscribe(term => {
+            this._filterData(term);
+        });
     }
 
     ngAfterContentInit() {

--- a/projects/cashmere/src/lib/typeahead/typeahead.module.ts
+++ b/projects/cashmere/src/lib/typeahead/typeahead.module.ts
@@ -6,9 +6,10 @@ import {FormFieldModule} from '../form-field/hc-form-field.module';
 import {IconModule} from '../icon/icon.module';
 import {CommonModule} from '@angular/common';
 import {InputModule} from '../input/input.module';
+import {ProgressIndicatorsModule} from '../progress-indicators/progress-indicators.module';
 
 @NgModule({
-    imports: [CommonModule, FormsModule, ReactiveFormsModule, FormFieldModule, IconModule, InputModule],
+    imports: [CommonModule, FormsModule, ReactiveFormsModule, FormFieldModule, IconModule, InputModule, ProgressIndicatorsModule],
     exports: [TypeaheadComponent, TypeaheadItemComponent],
     declarations: [TypeaheadComponent, TypeaheadItemComponent]
 })

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -252,7 +252,7 @@ const docs: DocItem[] = [
         id: 'typeahead',
         name: 'Typeahead',
         category: 'forms',
-        examples: ['typeahead-overview', 'typeahead-stacked', 'typeahead-highlighting', 'typeahead-highlighting-object', 'typeahead-error']
+        examples: ['typeahead-overview', 'typeahead-stacked', 'typeahead-highlighting', 'typeahead-highlighting-object', 'typeahead-error', 'typeahead-fetch']
     },
     {
         id: 'xanthos-file-upload',


### PR DESCRIPTION
Add debounce to prevent the valueChange event from emitting while user is still typing. Add a
configurable spinner that can be toggled on and off to show that the typeahead is working. Add an example demonstrating new functionality fetching data from remote API.
