### PR TITLE
fix(typeahead/typeahead title): fix keystrokes being ignored and error

### DIFF
--- a/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.html
+++ b/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.html
@@ -1,10 +1,10 @@
 <div class="typeahead-title">
-    <div class="typeahead-before" *ngIf="!isTypeaheadShown" (click)="hideTitle()" >
+    <div [ngClass]="{'typeahead-before': true, hidden: isTypeaheadShown}" (click)="hideTitle()">
         <span class="title-text">{{startingValue}}</span>
         <hc-icon fontSet="fa" fontIcon="fa-search" class="search"></hc-icon>
         <hc-icon fontSet="fa" fontIcon="fa-search" class="search-right"></hc-icon>
     </div>
-    <div class="typeahead-after" *ngIf="isTypeaheadShown">
+    <div [ngClass]="{'typeahead-after': true, hidden: !isTypeaheadShown}">
         <ng-content></ng-content>
     </div>
 </div>

--- a/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.scss
+++ b/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.scss
@@ -1,9 +1,9 @@
 @import '../sass/_colors.scss';
 
 :host {
-  &.full-width {
-    width: 100%;
-  }
+    &.full-width {
+        width: 100%;
+    }
 }
 
 .typeahead-title {
@@ -54,4 +54,8 @@
     hc-icon.search-right {
         opacity: 1;
     }
+}
+
+.hidden {
+    display: none;
 }


### PR DESCRIPTION
up, down, esc, enter, etc keystrokes were no longer working properly. Typeahead title was causing
an error in the console.

- hide the typeahead in the title component rather than not rendering it all. This ensures that all event handlers get attached properly and that the component does not get updated after the change lifecycle hook has ran which was causing console errors
- fix the handling of keystrokes so that all keys are being detected properly in the typeahead