### PR TITLE
feat(daterange): WCASHMERE-164: Fix many issues with daterange

### DIFF
--- a/projects/cashmere-examples/src/lib/date-range-time/date-range-time-example.component.html
+++ b/projects/cashmere-examples/src/lib/date-range-time/date-range-time-example.component.html
@@ -14,7 +14,7 @@
             #pickerOne
         >
             <span class="value"> {{ range.fromDate | date:'h:mm a' }} - {{ range.toDate | date:'h:mm a' }} </span>
-            <hc-icon fontSet="far" fontIcon="fa-calendar" class="icon-right"></hc-icon>
+            <hc-icon fontSet="far" fontIcon="fa-calendar"></hc-icon>
         </button>
     </div>
 </div>

--- a/projects/cashmere-examples/src/lib/date-range/date-range-example.component.html
+++ b/projects/cashmere-examples/src/lib/date-range/date-range-example.component.html
@@ -14,7 +14,7 @@
             #pickerOne
         >
             <span class="value"> {{ range.fromDate | date:'MM/dd/yyyy' }} - {{ range.toDate | date:'MM/dd/yyyy' }} </span>
-            <hc-icon fontSet="far" fontIcon="fa-calendar" class="icon-right"></hc-icon>
+            <hc-icon fontSet="far" fontIcon="fa-calendar"></hc-icon>
         </button>
     </div>
 </div>

--- a/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.html
+++ b/projects/cashmere-examples/src/lib/datepicker/datepicker-example.component.html
@@ -5,7 +5,7 @@
             <input hcInput [hcDatepicker]="picker1" [(ngModel)]="date1" placeholder="Select date..." />
             <hc-datepicker-toggle hcSuffix [for]="picker1"></hc-datepicker-toggle>
             <hc-datepicker #picker1></hc-datepicker>
-            <hc-error>Please enter a valid date</hc-error>
+            <hc-error class="margin-small">Please enter a valid date</hc-error>
         </hc-form-field>
     </div>
 

--- a/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.html
+++ b/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.html
@@ -15,7 +15,7 @@
         <hc-error [innerText]="invalidDateLabel"></hc-error>
     </hc-form-field>
 </div>
-<hc-calendar
+<hc-calendar 
     [mode]="mode"
     [hourCycle]="hourCycle"
     [startAt]="selectedDate"

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.scss
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.scss
@@ -13,6 +13,10 @@
     font-weight: 400;
 }
 
+.hc-date-range-calendar-item .hc-form-field-error-wrapper {
+    margin-top: 1px;
+}
+
 .hc-date-range-calendar-wrapper {
     width: 338px;
 }

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.ts
@@ -49,6 +49,7 @@ export class PickerOverlayComponent implements OnInit, AfterViewInit {
     ngAfterViewInit(): void {
         if (this.calendarWrappers.first) {
             this.calendarWrappers.first.focusInput();
+            this.cd.detectChanges();
         }
         setTimeout(() => {
             this._isRangePreset();

--- a/projects/cashmere/src/lib/datepicker/calendar/calendar-header.html
+++ b/projects/cashmere/src/lib/datepicker/calendar/calendar-header.html
@@ -35,7 +35,9 @@
             [attr.aria-label]="periodButtonLabel"
         >
             {{ periodButtonText }}
-            <div class="hc-calendar-arrow" [class.hc-calendar-invert]="calendar.currentView != 'month'"></div>
+            <div class="hc-calendar-arrow" [class.hc-calendar-invert]="calendar.currentView != 'month'">
+                <hc-icon fontSet="fa" fontIcon="fa-chevron-down" hcIconSm></hc-icon>
+            </div>
         </button>
 
     </div>

--- a/projects/cashmere/src/lib/datepicker/calendar/calendar.component.scss
+++ b/projects/cashmere/src/lib/datepicker/calendar/calendar.component.scss
@@ -50,15 +50,13 @@ $hc-calendar-next-icon-transform: translateX(-2px) rotate(45deg);
 }
 
 .hc-calendar-arrow {
+
     display: inline-block;
-    width: 0;
-    height: 0;
-    border-left: $hc-calendar-arrow-size solid transparent;
-    border-right: $hc-calendar-arrow-size solid transparent;
-    border-top-width: $hc-calendar-arrow-size;
-    border-top-style: solid;
-    margin: 0 0 0 $hc-calendar-arrow-size;
+    width: 20px;
+    height: 12px;
+    margin: 0 0 0 5px;
     vertical-align: middle;
+    transition: 0.2s;
 
     &.hc-calendar-invert {
         transform: rotate(180deg);


### PR DESCRIPTION
The following issues have been fixed:

- throws `ExpressionChangedAfterItHasBeenCheckedError` whenever it is opened/closed
- chevron should animate
- too much padding on left (doesn't line up with other form elements when inline)
- remove `icon-right` class from the examples since it is not doing anything and is getting propagated all over (copy and paste)
- error message overlaps with month label (see screenshot)