### PR TITLE
fix(typeahead): fix the firing order of events

### DIFF
--- a/projects/cashmere/src/lib/typeahead/typeahead-item/typeahead-item.component.html
+++ b/projects/cashmere/src/lib/typeahead/typeahead-item/typeahead-item.component.html
@@ -1,3 +1,3 @@
-<div [ngClass]="{result: true, highlighted: _highlighted}" (click)="_itemSelected(value)">
+<div [ngClass]="{result: true, highlighted: _highlighted}" (mousedown)="_itemSelected(value)">
     <ng-content></ng-content>
 </div>

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.ts
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.ts
@@ -108,7 +108,6 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
         }
     }
 
-
     ngOnInit() {
         this._searchTerm = new FormControl(this._value);
         this._resultPanelHidden = true;
@@ -182,7 +181,6 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
         this._options.toArray().forEach(option => {
             const sub = option._selected.subscribe(() => {
                 this.itemSelectedDefault(option.value);
-                // this.hideResultPanel();
             });
 
             this._optionSubscriptions.push(sub);
@@ -264,15 +262,6 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
         }
 
         return currentScrollPosition;
-    }
-
-    _toggleShowResults() {
-        if (this._resultPanelHidden) {
-            this.showResultPanel();
-            this.valueChange.emit('');
-        } else {
-            this.hideResultPanel();
-        }
     }
 
     private showResultPanel() {
@@ -425,6 +414,7 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
 
     _blurHandler(event) {
         this._markAsTouched();
+        this.hideResultPanel();
         this.blur.emit(event);
     }
 


### PR DESCRIPTION
This fixes 2 issues that were affecting the typeahead and typeahead title. First, clicking outside
of the typeahead when using it in the title would not cause it to return to the title view instead
the typeahead stayed visible. Second, clikcing on a typeahead item to select would not cause it to
become the selected item because of event firing order.