### PR TITLE
fix(phone input): format initial value

### DIFF
--- a/projects/cashmere-examples/src/lib/input-phone-number/input-phone-number-example.component.html
+++ b/projects/cashmere-examples/src/lib/input-phone-number/input-phone-number-example.component.html
@@ -3,10 +3,20 @@
         <hc-form-field>
             <hc-label>Tel:</hc-label>
             <input hcInput hcPhoneMask
-            [formControl]="formDemoPhone" 
-            [preValue]="formDemoPhone.value" 
-            [phoneControl]="formDemoPhone" maxlength="14" 
-            [ngClass]="(formDemoPhone.invalid)? 'errmsg' : 'validmsg'">		
+                   [formControl]="formDemoPhone"
+                   [preValue]="formDemoPhone.value"
+                   [phoneControl]="formDemoPhone" maxlength="14"
+                   [ngClass]="(formDemoPhone.invalid)? 'errmsg' : 'validmsg'">
+            <hc-error>A valid phone number is required</hc-error>
+        </hc-form-field>
+
+        <hc-form-field>
+            <hc-label>Tel (with initial value):</hc-label>
+            <input hcInput hcPhoneMask
+                   [formControl]="formDemoPhoneInitVal"
+                   [preValue]="formDemoPhoneInitVal.value"
+                   [phoneControl]="formDemoPhoneInitVal" maxlength="14"
+                   [ngClass]="(formDemoPhoneInitVal.invalid)? 'errmsg' : 'validmsg'">
             <hc-error>A valid phone number is required</hc-error>
         </hc-form-field>
     </div>

--- a/projects/cashmere-examples/src/lib/input-phone-number/input-phone-number-example.component.ts
+++ b/projects/cashmere-examples/src/lib/input-phone-number/input-phone-number-example.component.ts
@@ -12,4 +12,5 @@ import {FormControl, Validators} from '@angular/forms';
 export class InputPhoneNumberExampleComponent {
 
     formDemoPhone = new FormControl('', [Validators.pattern(/^\(\d{3}\)\s\d{3}-\d{4}$/), Validators.required]);
+    formDemoPhoneInitVal = new FormControl('8015551234', [Validators.pattern(/^\(\d{3}\)\s\d{3}-\d{4}$/), Validators.required]);
 }

--- a/projects/cashmere/src/lib/input/phone-mask.directive.ts
+++ b/projects/cashmere/src/lib/input/phone-mask.directive.ts
@@ -1,99 +1,104 @@
-import { Directive, Input, AfterViewInit, OnDestroy, Renderer2, ViewContainerRef } from '@angular/core';
-import { AbstractControl } from '@angular/forms';
-import { SubscriptionLike } from 'rxjs';
+import {AfterViewInit, Directive, Input, OnDestroy, Renderer2, ViewContainerRef} from '@angular/core';
+import {AbstractControl} from '@angular/forms';
+import {SubscriptionLike} from 'rxjs';
 
 @Directive({
-  selector: '[hcPhoneMask]'
+    selector: '[hcPhoneMask]'
 })
 export class PhoneMaskDirective implements AfterViewInit, OnDestroy {
 
-  private _phoneControl: AbstractControl;
-  private _preValue: string;
+    private _phoneControl: AbstractControl;
+    private _preValue: string;
 
-  @Input()
-  set phoneControl(control: AbstractControl) {
-    this._phoneControl = control;
-  }
-  @Input()
-  set preValue(value: string) {
-    this._preValue = value;
-  }
-  private sub: SubscriptionLike;
+    @Input()
+    set phoneControl(control: AbstractControl) {
+        this._phoneControl = control;
+    }
 
-  constructor( private renderer: Renderer2, private _view: ViewContainerRef) {}
+    @Input()
+    set preValue(value: string) {
+        this._preValue = value;
+    }
 
-  ngAfterViewInit() {
-    let component_id: string = '#' + (this._view).element.nativeElement.id;
-    this.phoneValidate(component_id);
-  }
+    private sub: SubscriptionLike;
 
-  ngOnDestroy() {
-    this.sub.unsubscribe();
-  }
+    constructor(private renderer: Renderer2, private _view: ViewContainerRef) {
+    }
 
-  phoneValidate(id: string) {
-    this.sub = this._phoneControl.valueChanges.subscribe(data => {
-        let preInputValue: string = this._preValue;
-        let lastChar: string = preInputValue.substr(preInputValue.length - 1);
-        // Allow only numeric characters
-        let newVal = data.replace(/\D/g, '');
-        let start = this.renderer.selectRootElement(id).selectionStart;
-        let end = this.renderer.selectRootElement(id).selectionEnd;
-        // If deleting input characters
-        if (data.length < preInputValue.length) {
-            // Adjustment if character removed is ')'
-            if (preInputValue.length < start) {
-                if (lastChar === ')') {
-                    newVal = newVal.substr(0, newVal.length - 1);
-                }
-            }
-            // If no numbers then reset
-            if (newVal.length === 0) {
-                newVal = '';
-            } else if (newVal.length <= 3) {
-                // Change pattern match on delete to recognize non-numeric chars
-                newVal = newVal.replace(/^(\d{0,3})/, '($1');
-            } else if (newVal.length <= 6) {
-                newVal = newVal.replace(/^(\d{0,3})(\d{0,3})/, '($1) $2');
-            } else {
-                newVal = newVal.replace(/^(\d{0,3})(\d{0,3})(.*)/, '($1) $2-$3');
-            }
+    ngAfterViewInit() {
+        let component_id: string = '#' + (this._view).element.nativeElement.id;
+        this.phoneValidate(component_id);
+
+        // Format the initial value passed in
+        setTimeout(() => {
+            let newVal = this._getFormattedValue(this._preValue);
             this._phoneControl.setValue(newVal, {emitEvent: false});
-            this.renderer.selectRootElement(id).setSelectionRange(start, end);
-        // If adding input characters
-        } else {
-            let removedD = data.charAt(start);
-            // Don't show braces for empty value
-            if (newVal.length === 0) {
-                newVal = '';
-            } else if (newVal.length <= 3) {
-                // Don't show braces for empty groups at the end
-                newVal = newVal.replace(/^(\d{0,3})/, '($1)');
-            } else if (newVal.length <= 6) {
-                newVal = newVal.replace(/^(\d{0,3})(\d{0,3})/, '($1) $2');
-            } else {
-                newVal = newVal.replace(/^(\d{0,3})(\d{0,3})(.*)/, '($1) $2-$3');
-            }
-            // Check if in the process of typing a number out
-            if (preInputValue.length >= start) {
-                // Change cursor position after adding special characters
-                switch (removedD) {
-                case '(':
-                case ')':
-                case '-':
-                    start += 1; end += 1;
-                break;
-                case ')':
-                    start += 2; end += 2;
-                break;
+        }, 0);
+    }
+
+    ngOnDestroy() {
+        this.sub.unsubscribe();
+    }
+
+    phoneValidate(id: string) {
+        this.sub = this._phoneControl.valueChanges.subscribe(data => {
+            let preInputValue: string = this._preValue;
+            let lastChar: string = preInputValue.substr(preInputValue.length - 1);
+            // Allow only numeric characters
+            let newVal = data.replace(/\D/g, '');
+            let start = this.renderer.selectRootElement(id).selectionStart;
+            let end = this.renderer.selectRootElement(id).selectionEnd;
+            // If deleting input characters
+            if (data.length < preInputValue.length) {
+                // Adjustment if character removed is ')'
+                if (preInputValue.length < start) {
+                    if (lastChar === ')') {
+                        newVal = newVal.substr(0, newVal.length - 1);
+                    }
                 }
+
+                newVal = this._getFormattedValue(newVal);
                 this._phoneControl.setValue(newVal, {emitEvent: false});
                 this.renderer.selectRootElement(id).setSelectionRange(start, end);
+                // If adding input characters
             } else {
-                this._phoneControl.setValue(newVal, {emitEvent: false});
-                this.renderer.selectRootElement(id).setSelectionRange(start + 2, end + 2);
+                let removedD = data.charAt(start);
+                newVal = this._getFormattedValue(newVal);
+
+                // Check if in the process of typing a number out
+                if (preInputValue.length >= start) {
+                    // Change cursor position after adding special characters
+                    switch (removedD) {
+                        case '(':
+                        case ')':
+                        case '-':
+                            start += 1;
+                            end += 1;
+                            break;
+                    }
+                    this._phoneControl.setValue(newVal, {emitEvent: false});
+                    this.renderer.selectRootElement(id).setSelectionRange(start, end);
+                } else {
+                    this._phoneControl.setValue(newVal, {emitEvent: false});
+                    this.renderer.selectRootElement(id).setSelectionRange(start + 2, end + 2);
+                }
             }
+        });
+    }
+
+    private _getFormattedValue(newVal: string) {
+        // Don't show braces for empty value
+        if (newVal.length === 0) {
+            newVal = '';
+        } else if (newVal.length <= 3) {
+            // Don't show braces for empty groups at the end
+            newVal = newVal.replace(/^(\d{0,3})/, '($1)');
+        } else if (newVal.length <= 6) {
+            newVal = newVal.replace(/^(\d{0,3})(\d{0,3})/, '($1) $2');
+        } else {
+            newVal = newVal.replace(/^(\d{0,3})(\d{0,3})(.*)/, '($1) $2-$3').substr(0, 14);
         }
-    });
-  }
+
+        return newVal;
+    }
 }


### PR DESCRIPTION
Sorry, the reformatting from 2 spaces to 4 spaces makes it look like a lot more changes than there really are. There is a new example that helps see it work with or without an initial value. I made 3 main changes here though:
1. format the initial value (in ngAfterViewInit)
2. trim the overall length of the number so you can't paste in a 100 digit phone number
3. Remove a dead case ')' from the switch statement