### PR TITLE
fix(table sort): WCASHMERE-188: Fixed alignment on table headers

### DIFF
--- a/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.html
+++ b/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.html
@@ -1,34 +1,36 @@
-<table hc-table [dataSource]="dataSource" hcSort>
-    <!-- Position Column -->
-    <ng-container hcColumnDef="position">
-        <th hc-header-cell *hcHeaderCellDef hc-sort-header>No.</th>
-        <td hc-cell *hcCellDef="let element">{{ element.position }}</td>
-    </ng-container>
+<div class="table-container">
+    <table hc-table [dataSource]="dataSource" hcSort>
+        <!-- Position Column -->
+        <ng-container hcColumnDef="position">
+            <th hc-header-cell *hcHeaderCellDef hc-sort-header>No.</th>
+            <td hc-cell *hcCellDef="let element">{{ element.position }}</td>
+        </ng-container>
 
-    <!-- Name Column -->
-    <ng-container hcColumnDef="name" justify="right">
-        <th hc-header-cell *hcHeaderCellDef hc-sort-header>Right Align</th>
-        <td hc-cell *hcCellDef="let element">{{ element.name }}</td>
-    </ng-container>
+        <!-- Name Column -->
+        <ng-container hcColumnDef="name" justify="right">
+            <th hc-header-cell *hcHeaderCellDef hc-sort-header arrowPosition="before">Right Align</th>
+            <td hc-cell *hcCellDef="let element">{{ element.name }}</td>
+        </ng-container>
 
-    <!-- Weight Column -->
-    <ng-container hcColumnDef="weight" justify="center">
-        <th hc-header-cell *hcHeaderCellDef hc-sort-header>Center Align</th>
-        <td hc-cell *hcCellDef="let element">{{ element.weight }}</td>
-    </ng-container>
+        <!-- Weight Column -->
+        <ng-container hcColumnDef="weight" justify="center">
+            <th hc-header-cell *hcHeaderCellDef hc-sort-header>Center Align</th>
+            <td hc-cell *hcCellDef="let element">{{ element.weight }}</td>
+        </ng-container>
 
-    <!-- Discovered -->
-    <ng-container hcColumnDef="discovered" justify="right">
-        <th hc-header-cell *hcHeaderCellDef hc-sort-header arrowPosition="before">Left Indicator</th>
-        <td hc-cell *hcCellDef="let element">{{ element.discovered | date: 'fullDate' }}</td>
-    </ng-container>
+        <!-- Discovered -->
+        <ng-container hcColumnDef="discovered" justify="right">
+            <th hc-header-cell *hcHeaderCellDef hc-sort-header arrowPosition="before">Left Indicator</th>
+            <td hc-cell *hcCellDef="let element">{{ element.discovered | date: 'fullDate' }}</td>
+        </ng-container>
 
-    <!-- Symbol Column -->
-    <ng-container hcColumnDef="symbol">
-        <th hc-header-cell *hcHeaderCellDef>Symbol</th>
-        <td hc-cell *hcCellDef="let element">{{ element.symbol }}</td>
-    </ng-container>
+        <!-- Symbol Column -->
+        <ng-container hcColumnDef="symbol">
+            <th hc-header-cell *hcHeaderCellDef>Symbol</th>
+            <td hc-cell *hcCellDef="let element">{{ element.symbol }}</td>
+        </ng-container>
 
-    <tr hc-header-row *hcHeaderRowDef="displayedColumns"></tr>
-    <tr hc-row *hcRowDef="let row; columns: displayedColumns"></tr>
-</table>
+        <tr hc-header-row *hcHeaderRowDef="displayedColumns"></tr>
+        <tr hc-row *hcRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+</div>

--- a/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.scss
+++ b/projects/cashmere-examples/src/lib/table-sort/table-sort-example.component.scss
@@ -1,3 +1,9 @@
-table {
+.table-container {
     width: 100%;
+    overflow-x: auto;
+
+    table {
+        width: 100%;
+        min-width: 680px;
+    }
 }

--- a/projects/cashmere/src/lib/sass/table.scss
+++ b/projects/cashmere/src/lib/sass/table.scss
@@ -198,6 +198,10 @@ $row-selected-border-color: $white;
 
 @mixin hc-table-sort-header-right() {
     justify-content: right;
+
+    .hc-sort-header-button {
+        text-align: right;
+    }
 }
 
 @mixin hc-table-header-sortable() {

--- a/projects/cashmere/src/lib/sass/tables.scss
+++ b/projects/cashmere/src/lib/sass/tables.scss
@@ -5,8 +5,8 @@ $table-border: 1px solid $slate-gray-300 !default;
 $table-border-transparent: 1px solid transparent;
 $table-condensed-font-size: 13px;
 $header-border-thick: 1px solid $slate-gray-300 !default;
-$cell-padding: 8px 16px !default;
-$cell-padding-condensed: 6px 16px !default;
+$cell-padding: 8px 8px !default;
+$cell-padding-condensed: 6px 8px !default;
 $thead-font-size: 16px !default;
 $thead-font-color: $dark-blue !default;
 $thead-active-font-color: $green !default;
@@ -181,6 +181,10 @@ table.hc-table {
 
         .hc-sort-header-container {
             justify-content: right;
+            
+            .hc-sort-header-button {
+                text-align: right;
+            }
         }
     }
 

--- a/projects/cashmere/src/lib/table/table.md
+++ b/projects/cashmere/src/lib/table/table.md
@@ -104,9 +104,11 @@ that the table will be included in a composition of components that fills out it
 you can add sorting to the table by using HcSort and mutating the data provided to the table according to
 their outputs.
 
+#### Text Justification
+
 The text alignment of a column may be set using the `justify` property on the `ng-container` of a column.
-It defaults to a value of `left`, but my be set to `right` or `center`. Columns containing numerical data
-should typically be right aligned.
+It defaults to a value of `left`, but may be set to `right` or `center`. Columns containing numerical data
+should typically be right aligned. Please note that if the justification is set to `right`, the header filter indicator should be placed on the left side with `arrowPosition="before"`.
 
 To simplify the use case of having a table that can sort, and filter an array of data,
 the Cashmere library comes with a `HcTableDataSource` that has already implemented


### PR DESCRIPTION
Fixed alignment so that right align and left indicator justify correctly when stacked. Also, made it
clear in documentation that when using right align, the left indicator should also be used.