### PR TITLE
fix(sidenav): fix the active state of sidenav links

### DIFF
--- a/projects/cashmere/src/lib/sidenav/sidenav-link/sidenav-link.component.html
+++ b/projects/cashmere/src/lib/sidenav/sidenav-link/sidenav-link.component.html
@@ -5,7 +5,7 @@
         [title]="linkText"
         [routerLink]="routerLink"
         routerLinkActive="active"
-        [routerLinkActiveOptions]="{exact: true}"
+        [routerLinkActiveOptions]="{exact: true, __change_detection_hack__: routerLink}"
         class="sidenav-link"
         (click)="_stop($event)"
     >


### PR DESCRIPTION
It turns out that all of the trouble we were having with getting the correct sidenav link to be active is a bug in angular. This is the workaround most widely accepted. 

https://github.com/angular/angular/issues/18469#issuecomment-345436335