### PR TITLE
cleanup

### DIFF
--- a/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.ts
+++ b/projects/cashmere-examples/src/lib/select-forms/select-forms-example.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {FormControl} from '@angular/forms';
 
 /**
@@ -9,8 +9,12 @@ import {FormControl} from '@angular/forms';
     templateUrl: 'select-forms-example.component.html',
     styleUrls: ['select-forms-example.component.scss']
 })
-export class SelectFormsExampleComponent {
+export class SelectFormsExampleComponent implements OnInit {
     selectControl = new FormControl('chicken');
+
+    ngOnInit() {
+        this.selectControl.setValue('collard');
+    }
 
     setTaters() {
         this.selectControl.setValue('taters');

--- a/projects/cashmere-examples/src/lib/typeahead-title/typeahead-title-example.component.html
+++ b/projects/cashmere-examples/src/lib/typeahead-title/typeahead-title-example.component.html
@@ -1,12 +1,14 @@
 <div class="example-content">
     <form [formGroup]="form">
-        <hc-typeahead-title>
-            <hc-typeahead formControlName="item" (valueChange)="filterData($event)"
-                          (optionSelected)="optionSelected($event)" placeholder="Find a state">
-                <hc-typeahead-item *ngFor="let item of filteredData" [value]="item">
-                    {{item}}
-                </hc-typeahead-item>
-            </hc-typeahead>
-        </hc-typeahead-title>
+        <hc-form-field>
+            <hc-typeahead-title>
+                <hc-typeahead formControlName="item" (valueChange)="filterData($event)"
+                              (optionSelected)="optionSelected($event)" placeholder="Find a state">
+                    <hc-typeahead-item *ngFor="let item of filteredData" [value]="item">
+                        {{item}}
+                    </hc-typeahead-item>
+                </hc-typeahead>
+            </hc-typeahead-title>
+        </hc-form-field>
     </form>
 </div>

--- a/projects/cashmere/src/lib/select/select.component.ts
+++ b/projects/cashmere/src/lib/select/select.component.ts
@@ -1,4 +1,5 @@
 import {
+    AfterViewInit,
     Component,
     DoCheck,
     ElementRef,
@@ -41,7 +42,7 @@ export function _buildValueString(id: string | null, value: any): string {
     encapsulation: ViewEncapsulation.None,
     providers: [{provide: HcFormControlComponent, useExisting: forwardRef(() => SelectComponent)}]
 })
-export class SelectComponent extends HcFormControlComponent implements ControlValueAccessor, DoCheck {
+export class SelectComponent extends HcFormControlComponent implements ControlValueAccessor, DoCheck, AfterViewInit {
     private _uniqueInputId = `hc-select-${uniqueId++}`;
     private _form: NgForm | FormGroupDirective | null;
     private _value: any = '';
@@ -157,6 +158,10 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
     private onTouched: (val: any) => void = () => {
     };
 
+    ngAfterViewInit() {
+        this._applyValue();
+    }
+
     registerOnChange(fn: any) {
         this.onChange = fn;
     }
@@ -167,15 +172,19 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
 
     writeValue(value: any) {
         this._value = value;
-        const id: string | null = this._getOptionId(value);
+        this._applyValue();
+    }
+
+    _applyValue() {
+        const id: string | null = this._getOptionId(this._value);
         if (!this._nativeSelect) {
             return;
         }
         if (id == null) {
             const selectedIndex = this.placeholder ? 0 : -1;
-            this._renderer.setProperty(this._nativeSelect.nativeElement, 'selectedIndex', -1);
+            this._renderer.setProperty(this._nativeSelect.nativeElement, 'selectedIndex', selectedIndex);
         }
-        const valueString = _buildValueString(id, value);
+        const valueString = _buildValueString(id, this._value);
         this._renderer.setProperty(this._nativeSelect.nativeElement, 'value', valueString);
     }
 

--- a/projects/cashmere/src/lib/sidenav/sidenav.component.ts
+++ b/projects/cashmere/src/lib/sidenav/sidenav.component.ts
@@ -43,9 +43,6 @@ export class SidenavComponent implements AfterContentInit {
     readonly align = 'left';
     readonly mode = 'side';
 
-    @HostBinding()
-    tabindex = -1;
-
     @HostBinding('class.hc-sidenav')
     _sideNavClass = true;
 

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.html
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.html
@@ -1,9 +1,10 @@
 <div class="typeahead-container">
     <hc-form-field [inline]="true">
-        <input #input hcInput [formControl]="_searchTerm" (keydown.tab)="_handleTabKey($event)" (keydown.enter)="_stopPropogation($event)"
-               (keydown.arrowup)="_stopPropogation($event)" (keydown.arrowdown)="_stopPropogation($event)"
-               [placeholder]="placeholder" autocomplete="off" [title]="_value" (blur)="_blurHandler($event)"
-               (focus)="_focusHandler($event)"/>
+        <input #input hcInput [formControl]="_searchTerm" (keydown.tab)="_handleTabKey($event)"
+               (keydown.enter)="_stopPropogation($event)" (keydown.arrowup)="_stopPropogation($event)"
+               (keydown.arrowdown)="_stopPropogation($event)" [placeholder]="placeholder" [title]="_value"
+               autocomplete="disabelAutocompleteHack" name="forAutocompleteHackToWork"
+               (blur)="_blurHandler($event)" (focus)="_focusHandler($event)"/>
         <hc-error style="display: none;">parent is showing error message</hc-error>
     </hc-form-field>
 

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.html
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.html
@@ -2,7 +2,8 @@
     <hc-form-field [inline]="true">
         <input #input hcInput [formControl]="_searchTerm" (keydown.tab)="_handleTabKey($event)" (keydown.enter)="_stopPropogation($event)"
                (keydown.arrowup)="_stopPropogation($event)" (keydown.arrowdown)="_stopPropogation($event)"
-               [placeholder]="placeholder" autocomplete="off" [title]="_value" (blur)="_blurHandler($event)"/>
+               [placeholder]="placeholder" autocomplete="off" [title]="_value" (blur)="_blurHandler($event)"
+               (focus)="_focusHandler($event)"/>
         <hc-error style="display: none;">parent is showing error message</hc-error>
     </hc-form-field>
 

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.scss
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.scss
@@ -54,7 +54,7 @@ hc-typeahead {
     }
 
     .hc-form-field-infix {
-        padding-right: 25px;
+        padding-right: 0;
         padding-left: 30px;
     }
 

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.ts
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.ts
@@ -111,7 +111,6 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
     ngOnInit() {
         this._searchTerm = new FormControl(this._value);
         this._resultPanelHidden = true;
-        document.body.addEventListener('click', this.handleClick.bind(this));
 
         // add subscription and debouncer for value changing in input field
         fromEvent(this._inputRef.nativeElement, 'keyup').pipe(
@@ -146,36 +145,6 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
             );
         });
     }
-
-    private handleClick(event) {
-        const clickTarget = event.target as HTMLElement;
-        let clickedTypeahead = false;
-
-        // open results panel on click
-        if (clickTarget === this._inputRef.nativeElement) {
-            if (this._resultPanelHidden === true) {
-                this._resultPanelHidden = false;
-                this.valueChange.emit('');
-                clickedTypeahead = true;
-            } else {
-                clickedTypeahead = true;
-            }
-        }
-
-        // check if results exist
-        if (this._resultPanel) {
-            if (clickTarget === this._resultPanel.nativeElement ||
-                this._resultPanel.nativeElement.contains(clickTarget)) {
-                clickedTypeahead = true;
-            }
-        }
-
-        // if the click was not in the typeahead then close the results panel
-        if (!clickedTypeahead) {
-            this.hideResultPanel();
-        }
-    }
-
 
     private listenForSelection() {
         this._options.toArray().forEach(option => {
@@ -416,6 +385,14 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
         this._markAsTouched();
         this.hideResultPanel();
         this.blur.emit(event);
+    }
+
+    _focusHandler(event) {
+        const clickTarget = event.target as HTMLElement;
+        if (clickTarget === this._inputRef.nativeElement && this._resultPanelHidden === true) {
+            this._resultPanelHidden = false;
+            this.valueChange.emit('');
+        }
     }
 
     _getHighlightedIndex() {

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.ts
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.ts
@@ -388,11 +388,8 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
     }
 
     _focusHandler(event) {
-        const clickTarget = event.target as HTMLElement;
-        if (clickTarget === this._inputRef.nativeElement && this._resultPanelHidden === true) {
-            this._resultPanelHidden = false;
-            this.valueChange.emit('');
-        }
+        this._resultPanelHidden = false;
+        this.valueChange.emit('');
     }
 
     _getHighlightedIndex() {


### PR DESCRIPTION
Several cleanup items on some odd bugs on the following components:
- typeahead: when used inside the sidenav, it would collapse results when clicking on the scrollbar of the results
- typeahead: browser autofill was triggering and it is very distracting and not beneficial on a typeahead
- typeahead: other miscellaneous clean up
- select: setting a selected value for the select box in the ngOnInit was not updating the UI with that value selected
