### PR TITLE
fix(typeahead): fix issues with disabled state

### DIFF
--- a/projects/cashmere-examples/src/lib/typeahead-overview/typeahead-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/typeahead-overview/typeahead-overview-example.component.html
@@ -2,11 +2,24 @@
     <form [formGroup]="form">
         <hc-form-field [inline]="true">
             <hc-label>States:</hc-label>
-            <hc-typeahead formControlName="item" (valueChange)="filterData($event)" (optionSelected)="optionSelected($event)" placeholder="Click to search">
+            <hc-typeahead formControlName="item" (valueChange)="filterData($event)" (optionSelected)="optionSelected($event)"
+                          placeholder="Click to search">
                 <hc-typeahead-item *ngFor="let item of filteredData" [value]="item">
                     {{item}}
                 </hc-typeahead-item>
             </hc-typeahead>
         </hc-form-field>
+
+        <div style="padding-top: 20px;">
+            <hc-form-field [inline]="true">
+                <hc-label>Disabled:</hc-label>
+                <hc-typeahead formControlName="item" (valueChange)="filterData($event)" (optionSelected)="optionSelected($event)"
+                              placeholder="Click to search" [disabled]="true">
+                    <hc-typeahead-item *ngFor="let item of filteredData" [value]="item">
+                        {{item}}
+                    </hc-typeahead-item>
+                </hc-typeahead>
+            </hc-form-field>
+        </div>
     </form>
 </div>

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.ts
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.ts
@@ -109,7 +109,7 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
     }
 
     ngOnInit() {
-        this._searchTerm = new FormControl(this._value);
+        this._searchTerm = new FormControl({value: this._value, disabled: this.disabled});
         this._resultPanelHidden = true;
 
         // add subscription and debouncer for value changing in input field
@@ -338,6 +338,9 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
     }
 
     set disabled(disabledVal) {
+        if (this._searchTerm) {
+            this._searchTerm.patchValue({disabled: disabledVal});
+        }
         this._isDisabled = parseBooleanAttribute(disabledVal);
     }
 


### PR DESCRIPTION
Clicking on the typehead even when it was disabled would still cause it to show all of the results.
The disabled state now works correctly.