### PR TITLE
fix(typeahead): fix issues with disabled state

### DIFF
--- a/projects/cashmere-examples/src/lib/typeahead-highlighting-object/typeahead-highlighting-object-example.component.html
+++ b/projects/cashmere-examples/src/lib/typeahead-highlighting-object/typeahead-highlighting-object-example.component.html
@@ -2,7 +2,8 @@
     <form [formGroup]="form">
         <hc-form-field [inline]="true">
             <hc-label>States:</hc-label>
-            <hc-typeahead formControlName="item" (valueChange)="filterData($event)" (optionSelected)="optionSelected($event)">
+            <hc-typeahead formControlName="item" (valueChange)="filterData($event)" (optionSelected)="optionSelected($event)"
+                          [disabled]="disabled">
                 <hc-typeahead-item *ngFor="let item of filteredData" [value]="item">
                     <div>
                         <p [innerHTML]="item.name | hcHighlight: typedChars"></p>
@@ -12,5 +13,9 @@
                 </hc-typeahead-item>
             </hc-typeahead>
         </hc-form-field>
+
+        <div style="padding-top: 20px;">
+            <button hc-button buttonStyle="secondary" (click)="toggleDisabled()">{{ buttonLabel }}</button>
+        </div>
     </form>
 </div>

--- a/projects/cashmere-examples/src/lib/typeahead-highlighting-object/typeahead-highlighting-object-example.component.ts
+++ b/projects/cashmere-examples/src/lib/typeahead-highlighting-object/typeahead-highlighting-object-example.component.ts
@@ -10,49 +10,62 @@ export class TypeaheadHighlightingObjectExampleComponent implements OnInit {
     form: FormGroup;
     filteredData: object[] = [];
     typeaheadData = [
-        {'name': 'Alabama',
-         'year': 1819,
-         'flower': 'Camellia'
+        {
+            'name': 'Alabama',
+            'year': 1819,
+            'flower': 'Camellia'
         },
-        {'name': 'Alaska',
-        'year': 1959,
-        'flower': 'Forget-Me-Not'
+        {
+            'name': 'Alaska',
+            'year': 1959,
+            'flower': 'Forget-Me-Not'
         },
-        {'name': 'Arizona',
-        'year': 1912,
-        'flower': 'Saguaro Blossom'
+        {
+            'name': 'Arizona',
+            'year': 1912,
+            'flower': 'Saguaro Blossom'
         },
-        {'name': 'Arkansas',
-        'year': 1836,
-        'flower': 'Apple Blossom'
+        {
+            'name': 'Arkansas',
+            'year': 1836,
+            'flower': 'Apple Blossom'
         },
-        {'name': 'California',
-        'year': 1850,
-        'flower': 'California Poppy'
+        {
+            'name': 'California',
+            'year': 1850,
+            'flower': 'California Poppy'
         },
-        {'name': 'Colorado',
-        'year': 1876,
-        'flower': 'Blue Columbine'
+        {
+            'name': 'Colorado',
+            'year': 1876,
+            'flower': 'Blue Columbine'
         },
-        {'name': 'Connecticut',
-        'year': 1788,
-        'flower': 'Mountain Laurel'
+        {
+            'name': 'Connecticut',
+            'year': 1788,
+            'flower': 'Mountain Laurel'
         },
-        {'name': 'Delaware',
-        'year': 1787,
-        'flower': 'Peach Blossom'
+        {
+            'name': 'Delaware',
+            'year': 1787,
+            'flower': 'Peach Blossom'
         },
-        {'name': 'Florida',
-        'year': 1845,
-        'flower': 'Orange Blossom'
+        {
+            'name': 'Florida',
+            'year': 1845,
+            'flower': 'Orange Blossom'
         },
-        {'name': 'Georgia',
-        'year': 1788,
-        'flower': 'Cherokee Rose'
+        {
+            'name': 'Georgia',
+            'year': 1788,
+            'flower': 'Cherokee Rose'
         }
     ];
 
     typedChars = '';
+
+    disabled = false;
+    buttonLabel = 'Disable';
 
     constructor(private fb: FormBuilder) {
     }
@@ -68,7 +81,7 @@ export class TypeaheadHighlightingObjectExampleComponent implements OnInit {
         this.setValue(term);
         if (term) {
             this.filteredData = this.typeaheadData.filter(item => item.name.toLowerCase().indexOf(term.toLowerCase()) > -1
-            || item.flower.toLowerCase().indexOf(term.toLowerCase()) > -1);
+                || item.flower.toLowerCase().indexOf(term.toLowerCase()) > -1);
         } else {
             this.filteredData = this.typeaheadData;
         }
@@ -80,15 +93,20 @@ export class TypeaheadHighlightingObjectExampleComponent implements OnInit {
 
     formatDisplay(item) {
         if (!item) {
-          return '';
+            return '';
         }
         return item.name + ' - ' + item.year;
-      }
+    }
 
     private setValue(item) {
         const control = this.form.get('item');
         if (control) {
             control.setValue(item);
         }
+    }
+
+    toggleDisabled() {
+        this.disabled = !this.disabled;
+        this.buttonLabel = this.disabled ? 'Enable' : 'Disable';
     }
 }

--- a/projects/cashmere-examples/src/lib/typeahead-overview/typeahead-overview-example.component.html
+++ b/projects/cashmere-examples/src/lib/typeahead-overview/typeahead-overview-example.component.html
@@ -3,7 +3,7 @@
         <hc-form-field [inline]="true">
             <hc-label>States:</hc-label>
             <hc-typeahead formControlName="item" (valueChange)="filterData($event)" (optionSelected)="optionSelected($event)"
-                          placeholder="Click to search">
+                          placeholder="Click to search" [disabled]="disabled">
                 <hc-typeahead-item *ngFor="let item of filteredData" [value]="item">
                     {{item}}
                 </hc-typeahead-item>
@@ -11,15 +11,7 @@
         </hc-form-field>
 
         <div style="padding-top: 20px;">
-            <hc-form-field [inline]="true">
-                <hc-label>Disabled:</hc-label>
-                <hc-typeahead formControlName="item" (valueChange)="filterData($event)" (optionSelected)="optionSelected($event)"
-                              placeholder="Click to search" [disabled]="true">
-                    <hc-typeahead-item *ngFor="let item of filteredData" [value]="item">
-                        {{item}}
-                    </hc-typeahead-item>
-                </hc-typeahead>
-            </hc-form-field>
+            <button hc-button buttonStyle="secondary" (click)="toggleDisabled()">{{ buttonLabel }}</button>
         </div>
     </form>
 </div>

--- a/projects/cashmere-examples/src/lib/typeahead-overview/typeahead-overview-example.component.ts
+++ b/projects/cashmere-examples/src/lib/typeahead-overview/typeahead-overview-example.component.ts
@@ -23,6 +23,9 @@ export class TypeaheadOverviewExampleComponent implements OnInit {
         'Georgia'
     ];
 
+    disabled = false;
+    buttonLabel = 'Disable';
+
     constructor(private fb: FormBuilder) {
     }
 
@@ -50,5 +53,10 @@ export class TypeaheadOverviewExampleComponent implements OnInit {
         if (control) {
             control.setValue(item);
         }
+    }
+
+    toggleDisabled() {
+        this.disabled = !this.disabled;
+        this.buttonLabel = this.disabled ? 'Enable' : 'Disable';
     }
 }

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.ts
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.ts
@@ -339,7 +339,11 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
 
     set disabled(disabledVal) {
         if (this._searchTerm) {
-            this._searchTerm.patchValue({disabled: disabledVal});
+            if (disabledVal) {
+                this._searchTerm.disable();
+            } else {
+                this._searchTerm.enable();
+            }
         }
         this._isDisabled = parseBooleanAttribute(disabledVal);
     }


### PR DESCRIPTION
Clicking on the typeahead even when it is disabled caused the results to be revealed. Now the
results will not be shown and the input cannot be focused when the component is disabled.