### PR TITLE
feat(table): WCASHMERE-213: updated table styles

### DIFF
--- a/projects/cashmere/src/lib/sass/table.scss
+++ b/projects/cashmere/src/lib/sass/table.scss
@@ -65,6 +65,8 @@ $row-selected-border-color: $white;
 }
 
 @mixin hc-table-body-row() {
+    height: 48px;
+    
     &:nth-child(2n) {
         background-color: $row-color;
     }
@@ -79,7 +81,7 @@ $row-selected-border-color: $white;
 }
 
 @mixin hc-table-body-cell() {
-    vertical-align: top;
+    vertical-align: middle;
     border-bottom: none !important;
 }
 


### PR DESCRIPTION
Fixed min-height of table row to 48px and ensured that anything larger still bound by row padding.
Also centered content vertically in rows.