### PR TITLE
feat(typeahead title): add red border to empty typeahead title

### DIFF
--- a/projects/cashmere-examples/src/lib/typeahead-title-multiple/typeahead-title-multiple-example.component.html
+++ b/projects/cashmere-examples/src/lib/typeahead-title-multiple/typeahead-title-multiple-example.component.html
@@ -1,21 +1,25 @@
 <div class="example-content">
     <form [formGroup]="form">
-        <hc-typeahead-title>
-            <hc-typeahead formControlName="stateItem" (valueChange)="filterStateData($event)"
-                          (optionSelected)="stateSelected($event)" placeholder="Find a state">
-                <hc-typeahead-item *ngFor="let item of filteredStateData" [value]="item">
-                    {{item}}
-                </hc-typeahead-item>
-            </hc-typeahead>
-        </hc-typeahead-title>
+        <hc-form-field>
+            <hc-typeahead-title>
+                <hc-typeahead formControlName="stateItem" (valueChange)="filterStateData($event)"
+                              (optionSelected)="stateSelected($event)" placeholder="Find a state">
+                    <hc-typeahead-item *ngFor="let item of filteredStateData" [value]="item">
+                        {{item}}
+                    </hc-typeahead-item>
+                </hc-typeahead>
+            </hc-typeahead-title>
+        </hc-form-field>
 
-        <hc-typeahead-title>
-            <hc-typeahead formControlName="cityItem" (valueChange)="filterCityData($event)"
-                          (optionSelected)="citySelected($event)" placeholder="Find a city">
-                <hc-typeahead-item *ngFor="let item of filteredCityData" [value]="item">
-                    {{item}}
-                </hc-typeahead-item>
-            </hc-typeahead>
-        </hc-typeahead-title>
+        <hc-form-field>
+            <hc-typeahead-title>
+                <hc-typeahead formControlName="cityItem" (valueChange)="filterCityData($event)"
+                              (optionSelected)="citySelected($event)" placeholder="Find a city">
+                    <hc-typeahead-item *ngFor="let item of filteredCityData" [value]="item">
+                        {{item}}
+                    </hc-typeahead-item>
+                </hc-typeahead>
+            </hc-typeahead-title>
+        </hc-form-field>
     </form>
 </div>

--- a/projects/cashmere-examples/src/lib/typeahead-title-multiple/typeahead-title-multiple-example.component.ts
+++ b/projects/cashmere-examples/src/lib/typeahead-title-multiple/typeahead-title-multiple-example.component.ts
@@ -35,7 +35,7 @@ export class TypeaheadTitleMultipleExampleComponent implements OnInit {
 
     ngOnInit(): void {
         this.form = this.fb.group({
-            stateItem: [''],
+            stateItem: ['Colorado'],
             cityItem: ['']
         });
     }

--- a/projects/cashmere-examples/src/lib/typeahead-title-no-alert/typeahead-title-no-alert-example.component.html
+++ b/projects/cashmere-examples/src/lib/typeahead-title-no-alert/typeahead-title-no-alert-example.component.html
@@ -1,0 +1,14 @@
+<div class="example-content">
+    <form [formGroup]="form">
+        <hc-form-field>
+            <hc-typeahead-title [alertOnEmpty]="false">
+                <hc-typeahead formControlName="item" (valueChange)="filterData($event)"
+                              (optionSelected)="optionSelected($event)" placeholder="Find a state">
+                    <hc-typeahead-item *ngFor="let item of filteredData" [value]="item">
+                        {{item}}
+                    </hc-typeahead-item>
+                </hc-typeahead>
+            </hc-typeahead-title>
+        </hc-form-field>
+    </form>
+</div>

--- a/projects/cashmere-examples/src/lib/typeahead-title-no-alert/typeahead-title-no-alert-example.component.ts
+++ b/projects/cashmere-examples/src/lib/typeahead-title-no-alert/typeahead-title-no-alert-example.component.ts
@@ -2,10 +2,10 @@ import {Component, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup} from '@angular/forms';
 
 @Component({
-    selector: 'hc-typeahead-title-example',
-    templateUrl: './typeahead-title-example.component.html'
+    selector: 'hc-typeahead-title-no-alert-example',
+    templateUrl: './typeahead-title-no-alert-example.component.html'
 })
-export class TypeaheadTitleExampleComponent implements OnInit {
+export class TypeaheadTitleNoAlertExampleComponent implements OnInit {
 
     form: FormGroup;
     filteredData: string[] = [];

--- a/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.html
+++ b/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.html
@@ -1,5 +1,5 @@
 <div class="typeahead-title">
-    <div [ngClass]="{'typeahead-before': true, hidden: _isTypeaheadShown}" (click)="_hideTitle()">
+    <div [ngClass]="{'typeahead-before': true, hidden: _isTypeaheadShown, alert: _drawAttention()}" (click)="_hideTitle()">
         <span class="title-text" [ngClass]="{'value-updated': _value}">{{_displayValue}}</span>
         <hc-icon fontSet="fa" fontIcon="fa-search" class="search"></hc-icon>
         <hc-icon fontSet="fa" fontIcon="fa-search" class="search-right"></hc-icon>

--- a/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.scss
+++ b/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.scss
@@ -48,8 +48,8 @@
         opacity: 0;
         transition: 0.2s;
         position: absolute;
-        right: 14px;
-        top: 15px;
+        right: 12px;
+        top: 14px;
     }
 }
 

--- a/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.scss
+++ b/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.scss
@@ -19,6 +19,10 @@
     transition: 0.2s;
     margin-left: -12px;
 
+    &.alert {
+        border: 2px solid $wcf-red;
+    }
+
     span.title-text {
         font-size: 20px;
         font-family: 'Montserrat', Arial, Helvetica, sans-serif;

--- a/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.ts
+++ b/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, ContentChildren, QueryList} from '@angular/core';
+import {AfterViewInit, Component, ContentChild, Input} from '@angular/core';
 
 import {TypeaheadComponent} from '../typeahead/typeahead.component';
 
@@ -10,38 +10,42 @@ import {TypeaheadComponent} from '../typeahead/typeahead.component';
 export class TypeaheadTitleComponent implements AfterViewInit {
     DEFAULT_PLACEHOLDER = 'Typeahead Placeholder';
 
+    /** Whether or not the component should show the alert effect (red border) when it is empty. */
+    @Input()
+    alertOnEmpty: boolean = true;
+
     _isTypeaheadShown: boolean = false;
     _value: string;
     _placeholder: string;
     _displayValue: string;
 
-    @ContentChildren(TypeaheadComponent)
-    _typeahead: QueryList<TypeaheadComponent>;
+    @ContentChild(TypeaheadComponent, {static: false})
+    _typeahead: TypeaheadComponent;
 
     _hideTitle() {
         this._isTypeaheadShown = true;
         setTimeout(() => {
-            this._typeahead.first.setFocus();
+            this._typeahead.setFocus();
         });
     }
 
     ngAfterViewInit() {
-        if (this._typeahead.first) {
-            this._placeholder = this._typeahead.first._inputRef.nativeElement.getAttribute('placeholder');
-            this._typeahead.first.optionSelected.subscribe(option => {
+        if (this._typeahead) {
+            this._placeholder = this._typeahead._inputRef.nativeElement.getAttribute('placeholder');
+            this._typeahead.optionSelected.subscribe(option => {
                 this._isTypeaheadShown = false;
             });
 
-            this._typeahead.first.registerOnChange(this._updateValue.bind(this));
+            this._typeahead.registerOnChange(this._updateValue.bind(this));
 
-            this._typeahead.first.blur.subscribe(event => {
+            this._typeahead.blur.subscribe(event => {
                 // Prevents the click on the result panel causing the typeahead to disappear before the value can be sent
-                if (this._typeahead.first._resultPanelHidden === true) {
+                if (this._typeahead._resultPanelHidden === true) {
                     this._isTypeaheadShown = false;
                 }
             });
 
-            setTimeout(() => this._updateValue(this._typeahead.first.value));
+            setTimeout(() => this._updateValue(this._typeahead.value));
         }
 
         this._refreshDisplayValue();
@@ -56,5 +60,9 @@ export class TypeaheadTitleComponent implements AfterViewInit {
         setTimeout(() => {
             this._displayValue = this._value || this._placeholder || this.DEFAULT_PLACEHOLDER;
         });
+    }
+
+    _drawAttention() {
+        return this.alertOnEmpty && this._typeahead && !this._typeahead._value;
     }
 }

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -279,7 +279,7 @@ const docs: DocItem[] = [
         id: 'typeahead-title',
         name: 'Typeahead Title',
         category: 'forms',
-        examples: ['typeahead-title', 'typeahead-title-multiple']
+        examples: ['typeahead-title', 'typeahead-title-multiple', 'typeahead-title-no-alert']
     },
     {
         id: 'xanthos-file-upload',


### PR DESCRIPTION
The red border is intended to draw the users attention to the empty component. It is implemented as
an input so that this effect can be disabled if desired.