### PR TITLE
fix(typeahead title): fix the typeahead title background color

### DIFF
--- a/projects/cashmere-examples/src/lib/typeahead-title-multiple/typeahead-title-multiple-example.component.html
+++ b/projects/cashmere-examples/src/lib/typeahead-title-multiple/typeahead-title-multiple-example.component.html
@@ -1,4 +1,4 @@
-<div class="example-content">
+<div class="example-content" style="background-color: lightgrey; margin: 0 auto; padding: 30px;">
     <form [formGroup]="form">
         <hc-form-field>
             <hc-typeahead-title>

--- a/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.scss
+++ b/projects/cashmere/src/lib/typeahead-title/typeahead-title.component.scss
@@ -8,6 +8,8 @@
 
 .typeahead-title {
     width: 100%;
+    background-color: $white;
+    border-radius: 4px;
 }
 
 .typeahead-before {
@@ -18,6 +20,7 @@
     cursor: pointer;
     transition: 0.2s;
     margin-left: -12px;
+    background-color: $white;
 
     &.alert {
         border: 2px solid $wcf-red;


### PR DESCRIPTION
Fix the typeahead title so that it has a consistent white background. Provide an example that
demonstrates this as well.