### PR TITLE
fix(colors): make blue-darkest color available to consume

### DIFF
--- a/projects/cashmere/src/lib/sass/_colors.scss
+++ b/projects/cashmere/src/lib/sass/_colors.scss
@@ -54,6 +54,7 @@ $wcf-blue: #406181;
 $wcf-blue-alt: #4890d9;
 $blue-light: #A1B0BF;
 $blue-dark: #1F3040;
+$blue-darkest: #0D1828;
 $success: #78BF40;
 $success-bg: #EBF6E2;
 $warning: #FFB13F;
@@ -69,11 +70,11 @@ $blue-glow: $wcf-blue-alt;
 $white: #ffffff;
 $gray-02: #f6f7f7;
 $gray-05: #e9eaeb;
-$gray-10: #d7d8da;   // use for disabled state and divider lines
+$gray-10: #d7d8da; // use for disabled state and divider lines
 $gray-30: #afb2b4;
-$gray-50: #878b8f;  // border default and label default
-$gray-70: #5e646a;  // use as default icon color
-$gray-90: #363e44;  // text default
+$gray-50: #878b8f; // border default and label default
+$gray-70: #5e646a; // use as default icon color
+$gray-90: #363e44; // text default
 $black: #0e171f;
 
 // General Color Vars

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.ts
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.ts
@@ -62,7 +62,7 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
     @Input()
     debounceTime: number = 200;
 
-    /** Toggle to show and hide the searching filter to give user feedback */
+    /** Toggle to show and hide the searching spinner to provide the user with feedback */
     /** (it does not automatically turn on and off, you need to manually control it), default false */
     @Input()
     showSpinner: boolean = false;


### PR DESCRIPTION
- Expose $blue-darkest in the colors file for external consumption.
- Snuck in a little doc change for typeahead
- Looks like I used a different version of commitizen that worked a bit differently (new computer)