### PR TITLE
feat(sidenav): add ability to initialize open

### DIFF
--- a/projects/cashmere/src/lib/sidenav/sidenav-link/sidenav-link.component.html
+++ b/projects/cashmere/src/lib/sidenav/sidenav-link/sidenav-link.component.html
@@ -11,17 +11,20 @@
     >
         <ng-container *ngTemplateOutlet="linkContent"></ng-container>
     </a>
-    <div class="toggle-button" #toggle *ngIf="children?.length">
-        <hc-icon fontSet="fa" fontIcon="fa-chevron-down" class="show-all" hcIconSm (click)="_toggleChildren($event)"></hc-icon>
-    </div>
+    <ng-container *ngTemplateOutlet="toggleButton"></ng-container>
 </ng-template>
 
 <ng-template #hrefTemplate>
     <a [title]="linkText" [href]="uri" class="sidenav-link" target="_blank" (click)="_linkClickHandler($event)">
         <ng-container *ngTemplateOutlet="linkContent"></ng-container>
     </a>
-    <div class="toggle-button" #toggle *ngIf="children?.length">
-        <hc-icon fontSet="fa" fontIcon="fa-chevron-down" class="show-all" hcIconSm (click)="_toggleChildren($event)"></hc-icon>
+    <ng-container *ngTemplateOutlet="toggleButton"></ng-container>
+</ng-template>
+
+<ng-template #toggleButton>
+    <div class="toggle-button" [ngClass]="{'flip-around': open}" #toggle *ngIf="children?.length">
+        <hc-icon fontSet="fa" fontIcon="fa-chevron-down" class="show-all" hcIconSm
+                 (click)="_toggleChildren($event)"></hc-icon>
     </div>
 </ng-template>
 

--- a/projects/cashmere/src/lib/sidenav/sidenav-link/sidenav-link.component.scss
+++ b/projects/cashmere/src/lib/sidenav/sidenav-link/sidenav-link.component.scss
@@ -1,5 +1,11 @@
 @import '../../sass/colors';
 
+:host {
+    &:focus {
+        outline: none;
+    }
+}
+
 a {
     color: $white;
     font-size: 16px;

--- a/projects/cashmere/src/lib/sidenav/sidenav-link/sidenav-link.component.ts
+++ b/projects/cashmere/src/lib/sidenav/sidenav-link/sidenav-link.component.ts
@@ -38,6 +38,10 @@ export class SidenavLinkComponent implements AfterContentInit {
     @Input()
     linkText: string;
 
+    /** If this link should initialize to open (show children), assuming it has children. Default false. */
+    @Input()
+    open: boolean;
+
     // non-top level links emit this when their children change
     @Output()
     _childrenChanged: EventEmitter<SidenavLinkComponent> = new EventEmitter<SidenavLinkComponent>();
@@ -73,6 +77,8 @@ export class SidenavLinkComponent implements AfterContentInit {
 
             this._subscribeToChildrenChanges();
         }
+
+        this._childrenShown = this.open;
     }
 
     // Subscribe to children's events for when the child has children added/removed

--- a/src/app/demos/sidenav-demo/sidenav-demo.component.html
+++ b/src/app/demos/sidenav-demo/sidenav-demo.component.html
@@ -9,7 +9,7 @@
     </hc-sidenav-link>
 
     <hc-sidenav-link *ngIf="showActiveLink" routerLink="/components/button/examples" fontIcon="fa-credit-card"
-                     linkText="Button Examples">
+                     linkText="Button Examples (open)" [open]="true">
         <hc-sidenav-link *ngIf="showActiveLinkLater" uri="https://www.bing.com" fontIcon="fa-credit-card" linkText="Child Example">
             <hc-sidenav-link *ngIf="showActiveLinkWayLater"
                              routerLink="/demo/sidenav/bob" fontIcon="fa-credit-card"


### PR DESCRIPTION
I just made up a feature that wanted. Let me know if you hate it.

- Add the ability to initialize a link to open so that its children will be shown upon initialization.
After initialization, it works completely normal.
- Also, fixed an issue where after clicking to toggle a link (show children) the focus state added a white outline. We don't want that happening.