### PR TITLE
feat(select): add a borderless option

### DIFF
--- a/projects/cashmere-examples/src/lib/select-borderless/select-borderless-example.component.html
+++ b/projects/cashmere-examples/src/lib/select-borderless/select-borderless-example.component.html
@@ -1,0 +1,9 @@
+<div class="select-sample">
+    <hc-form-field inline>
+        <hc-select placeholder="Favorite Food" [borderless]="true">
+            <option value="1">Burger</option>
+            <option value="2">Ice Cream</option>
+            <option value="3">Pizza</option>
+        </hc-select>
+    </hc-form-field>
+</div>

--- a/projects/cashmere-examples/src/lib/select-borderless/select-borderless-example.component.scss
+++ b/projects/cashmere-examples/src/lib/select-borderless/select-borderless-example.component.scss
@@ -1,0 +1,3 @@
+.select-sample {
+    max-width: 140px;
+}

--- a/projects/cashmere-examples/src/lib/select-borderless/select-borderless-example.component.ts
+++ b/projects/cashmere-examples/src/lib/select-borderless/select-borderless-example.component.ts
@@ -1,0 +1,12 @@
+import {Component} from '@angular/core';
+
+/**
+ * @title Borderless Select Component
+ */
+@Component({
+    selector: 'hc-select-borderless-example',
+    templateUrl: 'select-borderless-example.component.html',
+    styleUrls: ['select-borderless-example.component.scss']
+})
+export class SelectBorderlessExampleComponent {
+}

--- a/projects/cashmere-examples/src/lib/select-object/select-object-example.component.ts
+++ b/projects/cashmere-examples/src/lib/select-object/select-object-example.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup} from '@angular/forms';
 
 /**
- * @title Standard Select Component
+ * @title Standard Select Component using objects for values
  */
 @Component({
     selector: 'hc-select-object-example',

--- a/projects/cashmere/src/lib/select/select.component.html
+++ b/projects/cashmere/src/lib/select/select.component.html
@@ -3,6 +3,7 @@
     <select
         #selectInput
         class="hc-select-input"
+        [ngClass]="{borderless: borderless}"
         [disabled]="disabled"
         (change)="_change($event, selectInput.value)"
         (focus)="focus.next();"

--- a/projects/cashmere/src/lib/select/select.component.scss
+++ b/projects/cashmere/src/lib/select/select.component.scss
@@ -75,6 +75,11 @@
         background-color: $slate-gray-100;
         color: tint($text, 60%);
     }
+
+    &.borderless {
+        border: none;
+        background-color: inherit;
+    }
 }
 
 .hc-select-disabled {

--- a/projects/cashmere/src/lib/select/select.component.ts
+++ b/projects/cashmere/src/lib/select/select.component.ts
@@ -8,8 +8,10 @@ import {
     HostBinding,
     Input,
     Optional,
-    Output, Renderer2,
-    Self, ViewChild,
+    Output,
+    Renderer2,
+    Self,
+    ViewChild,
     ViewEncapsulation
 } from '@angular/core';
 import {ControlValueAccessor, FormGroupDirective, NgControl, NgForm} from '@angular/forms';
@@ -103,6 +105,10 @@ export class SelectComponent extends HcFormControlComponent implements ControlVa
             this.onChange(val);
         }
     }
+
+    /** Set the display method of the select to be borderless instead of a standard select. Default false */
+    @Input()
+    borderless: boolean = false;
 
     @Output()
     readonly focus: EventEmitter<void> = new EventEmitter<void>();

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -196,7 +196,7 @@ const docs: DocItem[] = [
         id: 'select',
         name: 'Select',
         category: 'forms',
-        examples: ['select-standard', 'select-disabled', 'select-validation', 'select-forms', 'select-object'],
+        examples: ['select-standard', 'select-disabled', 'select-borderless', 'select-validation', 'select-forms', 'select-object'],
         usageDoc: true
     },
     {


### PR DESCRIPTION
The borderless option defaults to false so that it continues to work as it has. When set to true,
the select box will still function like a normal select box but it will not have a border around so
that it looks more floating.