### PR TITLE
fix(datepicker): fix validator when using min/max date

### DIFF
--- a/projects/cashmere-examples/src/lib/datepicker-min-max/datepicker-min-max-example.component.html
+++ b/projects/cashmere-examples/src/lib/datepicker-min-max/datepicker-min-max-example.component.html
@@ -1,28 +1,33 @@
 <div class="example-date-input">
-    <hc-form-field>
-        <hc-label>Date (with min and max):</hc-label>
-        <input hcInput [hcDatepicker]="picker1" [min]="min" [max]="max" [(ngModel)]="date1" placeholder="Custom date parsing..."
-               class="cursor-pointer"/>
-        <hc-datepicker-toggle hcSuffix [for]="picker1">
-        </hc-datepicker-toggle>
-        <hc-datepicker #picker1></hc-datepicker>
-    </hc-form-field>
+    <form [formGroup]="form">
+        <hc-form-field>
+            <hc-label>Date (with min and max):</hc-label>
+            <input hcInput [hcDatepicker]="picker1" [min]="min" [max]="max" [(ngModel)]="date1" placeholder="Custom date parsing..."
+                   class="cursor-pointer"/>
+            <hc-datepicker-toggle hcSuffix [for]="picker1">
+            </hc-datepicker-toggle>
+            <hc-datepicker #picker1></hc-datepicker>
+            <hc-error>What Happened?</hc-error>
+        </hc-form-field>
 
-    <hc-form-field>
-        <hc-label>Min Date:</hc-label>
-        <input hcInput [hcDatepicker]="picker2" [(ngModel)]="min" placeholder="Custom date parsing..."
-               class="cursor-pointer"/>
-        <hc-datepicker-toggle hcSuffix [for]="picker2">
-        </hc-datepicker-toggle>
-        <hc-datepicker #picker2></hc-datepicker>
-    </hc-form-field>
+        <hc-form-field>
+            <hc-label>Min Date:</hc-label>
+            <input hcInput [hcDatepicker]="picker2" [(ngModel)]="min" placeholder="Custom date parsing..."
+                   class="cursor-pointer"/>
+            <hc-datepicker-toggle hcSuffix [for]="picker2">
+            </hc-datepicker-toggle>
+            <hc-datepicker #picker2></hc-datepicker>
+            <hc-error>What Happened?</hc-error>
+        </hc-form-field>
 
-    <hc-form-field>
-        <hc-label>Max Date:</hc-label>
-        <input hcInput [hcDatepicker]="picker3" [(ngModel)]="max" placeholder="Custom date parsing..."
-               class="cursor-pointer"/>
-        <hc-datepicker-toggle hcSuffix [for]="picker3">
-        </hc-datepicker-toggle>
-        <hc-datepicker #picker3></hc-datepicker>
-    </hc-form-field>
+        <hc-form-field>
+            <hc-label>Max Date (in reactive form):</hc-label>
+            <input hcInput [hcDatepicker]="picker3" formControlName="maxDateControl" [max]="max" placeholder="Custom date parsing..."
+                   class="cursor-pointer"/>
+            <hc-datepicker-toggle hcSuffix [for]="picker3">
+            </hc-datepicker-toggle>
+            <hc-datepicker #picker3></hc-datepicker>
+            <hc-error>What Happened?</hc-error>
+        </hc-form-field>
+    </form>
 </div>

--- a/projects/cashmere-examples/src/lib/datepicker-min-max/datepicker-min-max-example.component.ts
+++ b/projects/cashmere-examples/src/lib/datepicker-min-max/datepicker-min-max-example.component.ts
@@ -1,4 +1,5 @@
 import {Component, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 
 @Component({
     selector: 'hc-datepicker-min-max-example',
@@ -11,11 +12,17 @@ export class DatepickerMinMaxExampleComponent implements OnInit {
     min = new Date();
     max = new Date();
 
-    constructor() {
+    form: FormGroup;
+
+    constructor(private fb: FormBuilder) {
     }
 
     ngOnInit() {
         this.min.setFullYear(this.min.getFullYear() - 1);
         this.max.setFullYear(this.max.getFullYear() + 1);
+
+        this.form = this.fb.group({
+            maxDateControl: ['', Validators.required]
+        });
     }
 }

--- a/projects/cashmere/src/lib/datepicker/datepicker-input/datepicker-input.directive.ts
+++ b/projects/cashmere/src/lib/datepicker/datepicker-input/datepicker-input.directive.ts
@@ -201,7 +201,7 @@ export class DatepickerInputDirective implements ControlValueAccessor, OnDestroy
     /** The form control validator for the min date. */
     private _minValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
         const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
-        return !this.min || !controlValue || this._dateAdapter.compareDate(this.min, controlValue) <= 0
+        return !this.min || !controlValue || this._dateAdapter.compareDatesByDatePart(this.min, controlValue) <= 0
             ? null
             : {hcDatepickerMin: {min: this.min, actual: controlValue}};
     };
@@ -209,7 +209,7 @@ export class DatepickerInputDirective implements ControlValueAccessor, OnDestroy
     /** The form control validator for the max date. */
     private _maxValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
         const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
-        return !this.max || !controlValue || this._dateAdapter.compareDate(this.max, controlValue) >= 0
+        return !this.max || !controlValue || this._dateAdapter.compareDatesByDatePart(this.max, controlValue) >= 0
             ? null
             : {hcDatepickerMax: {max: this.max, actual: controlValue}};
     };


### PR DESCRIPTION
The comparison for validity on the field was still using the old compareDate so if you selected the min or max it had the potential to fail validation (depending on the time of day).