### PR TITLE
fix(daterange): allow daterange errors to be cleared

### DIFF
--- a/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.html
+++ b/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.html
@@ -1,29 +1,29 @@
-<div class="form-container">
-    <hc-form-field class="hc-calendar-wrapper-form-field">
-        <hc-label [innerText]="prefixLabel"></hc-label>
-        <input
-            hcInput
-            hcDatepicker
-            [(ngModel)]="selectedDate"
-            required
-            (dateChange)="_onInputChange($event)"
-            [min]="minDate"
-            [max]="maxDate"
-            [_mode]="mode"
-            [_hourCycle]="hourCycle"
-            [disabled]="disableDateInput"
-        />
-        <hc-error [innerText]="invalidDateLabel"></hc-error>
-    </hc-form-field>
-</div>
-<hc-calendar
-    [mode]="mode"
-    [hourCycle]="hourCycle"
-    [startAt]="selectedDate"
-    [selected]="selectedDate"
-    [minDate]="minDate"
-    [maxDate]="maxDate"
-    (selectedChange)="_onCalendarChange($event)"
-    [dateFilter]="configStore.weekendFilter"
->
-</hc-calendar>
+<form [formGroup]="_form">
+    <div class="form-container">
+        <hc-form-field class="hc-calendar-wrapper-form-field">
+            <hc-label [innerText]="prefixLabel"></hc-label>
+            <input
+                hcInput
+                hcDatepicker
+                formControlName="selectedDate"
+                (dateChange)="_onInputChange($event)"
+                [min]="minDate"
+                [max]="maxDate"
+                [_mode]="mode"
+                [_hourCycle]="hourCycle"
+            />
+            <hc-error [innerText]="invalidDateLabel"></hc-error>
+        </hc-form-field>
+    </div>
+    <hc-calendar
+        [mode]="mode"
+        [hourCycle]="hourCycle"
+        [startAt]="selectedDate"
+        [selected]="selectedDate"
+        [minDate]="minDate"
+        [maxDate]="maxDate"
+        (selectedChange)="_onCalendarChange($event)"
+        [dateFilter]="configStore.weekendFilter"
+    >
+    </hc-calendar>
+</form>

--- a/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
+++ b/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
@@ -83,7 +83,6 @@ export class CalendarWrapperComponent implements OnChanges, OnInit {
     constructor(public configStore: ConfigStoreService) {}
 
     ngOnInit() {
-        console.log('onInit');
         const selectedDateControl = new FormControl(this.selectedDate, Validators.required);
         if (this.disableDateInput) {
             selectedDateControl.disable();

--- a/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
+++ b/projects/cashmere/src/lib/date-range/calendar-wrapper/calendar-wrapper.component.ts
@@ -1,19 +1,21 @@
 import {
-    Component,
-    ViewChild,
-    Input,
     ChangeDetectionStrategy,
-    ViewEncapsulation,
-    Output,
+    Component,
     EventEmitter,
+    HostBinding,
+    Input,
     OnChanges,
+    OnInit,
+    Output,
     SimpleChanges,
-    HostBinding
+    ViewChild,
+    ViewEncapsulation
 } from '@angular/core';
 import {ConfigStoreService} from '../services/config-store.service';
 import {CalendarComponent} from '../../datepicker/calendar/calendar.component';
 import {DatepickerInputDirective, HcDatepickerInputEvent} from '../../datepicker/datepicker-input/datepicker-input.directive';
 import {D} from '../../datepicker/datetime/date-formats';
+import {FormControl, FormGroup, Validators} from '@angular/forms';
 
 /** Component combining a calendar and input as a representation of a date  */
 @Component({
@@ -23,7 +25,7 @@ import {D} from '../../datepicker/datetime/date-formats';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
-export class CalendarWrapperComponent implements OnChanges {
+export class CalendarWrapperComponent implements OnChanges, OnInit {
     @HostBinding('class.hc-calendar-wrapper')
     _hostClass = true;
 
@@ -74,9 +76,20 @@ export class CalendarWrapperComponent implements OnChanges {
     @Input()
     disableDateInput: boolean = false;
 
+    _form: FormGroup;
+
     weekendFilter = () => true;
 
     constructor(public configStore: ConfigStoreService) {}
+
+    ngOnInit() {
+        console.log('onInit');
+        const selectedDateControl = new FormControl(this.selectedDate, Validators.required);
+        if (this.disableDateInput) {
+            selectedDateControl.disable();
+        }
+        this._form = new FormGroup({selectedDate: selectedDateControl});
+    }
 
     ngOnChanges(changes: SimpleChanges) {
         // Necessary to force view refresh

--- a/projects/cashmere/src/lib/date-range/date-range.module.ts
+++ b/projects/cashmere/src/lib/date-range/date-range.module.ts
@@ -4,7 +4,7 @@ import {DateRangeDirective} from './date-range/date-range.directive';
 import {PickerOverlayComponent} from './picker-overlay/picker-overlay.component';
 import {OverlayModule} from '@angular/cdk/overlay';
 import {CalendarWrapperComponent} from './calendar-wrapper/calendar-wrapper.component';
-import {FormsModule} from '@angular/forms';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {HcNativeDateModule} from '../datepicker/datetime/datetime.module';
 import {DatepickerModule} from '../datepicker/datepicker.module';
 import {FormFieldModule} from '../form-field/hc-form-field.module';
@@ -22,10 +22,12 @@ import {RadioButtonModule} from '../radio-button/radio-button.module';
         ButtonModule,
         RadioButtonModule,
         OverlayModule,
-        FormsModule
+        FormsModule,
+        ReactiveFormsModule
     ],
     declarations: [DateRangeDirective, CalendarWrapperComponent, PickerOverlayComponent],
     entryComponents: [PickerOverlayComponent],
     exports: [DateRangeDirective]
 })
-export class DateRangeModule {}
+export class DateRangeModule {
+}

--- a/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.html
+++ b/projects/cashmere/src/lib/date-range/picker-overlay/picker-overlay.component.html
@@ -19,7 +19,6 @@
         </div>
         <div class="hc-date-range-calendar-item hc-date-range-calendar-wrapper">
             <hc-calendar-wrapper
-                #durationToDateCalendar
                 [prefixLabel]="options.endDatePrefix"
                 [selectedDate]="_toDate"
                 [minDate]="_getDurationFromDateMinMax()"


### PR DESCRIPTION
If a parent form calls markAllAsTouched then the daterange calendar input shows errors and they will
return each time the calendar dialog is opened.