### PR TITLE
feat(typeahead): fix tabbing through typeahead component

### DIFF
--- a/projects/cashmere-examples/src/lib/typeahead-silent-focus/typeahead-silent-focus-example.component.html
+++ b/projects/cashmere-examples/src/lib/typeahead-silent-focus/typeahead-silent-focus-example.component.html
@@ -1,0 +1,28 @@
+<div class="example-content">
+    <form [formGroup]="form">
+        <div class="container">
+            <hc-form-field [inline]="true">
+                <hc-label>Non-Silent Focus:</hc-label>
+                <hc-typeahead formControlName="item" (valueChange)="filterData($event)" (optionSelected)="optionSelected($event)"
+                              [silentFocus]="false">
+                    <hc-typeahead-item *ngFor="let item of filteredData" [value]="item">
+                        {{item}}
+                    </hc-typeahead-item>
+                </hc-typeahead>
+                <hc-error>A valid state is required</hc-error>
+            </hc-form-field>
+        </div>
+
+        <div class="container">
+            <hc-form-field [inline]="true">
+                <hc-label>Silent Focus (default):</hc-label>
+                <hc-typeahead formControlName="item2" (valueChange)="filterData2($event)" (optionSelected)="optionSelected2($event)">
+                    <hc-typeahead-item *ngFor="let item of filteredData2" [value]="item">
+                        {{item}}
+                    </hc-typeahead-item>
+                </hc-typeahead>
+                <hc-error>A valid state is required</hc-error>
+            </hc-form-field>
+        </div>
+    </form>
+</div>

--- a/projects/cashmere-examples/src/lib/typeahead-silent-focus/typeahead-silent-focus-example.component.scss
+++ b/projects/cashmere-examples/src/lib/typeahead-silent-focus/typeahead-silent-focus-example.component.scss
@@ -1,0 +1,8 @@
+.example-content {
+    width: 400px;
+    height: 240px;
+
+    .container {
+        margin-top: 20px;
+    }
+}

--- a/projects/cashmere-examples/src/lib/typeahead-silent-focus/typeahead-silent-focus-example.component.ts
+++ b/projects/cashmere-examples/src/lib/typeahead-silent-focus/typeahead-silent-focus-example.component.ts
@@ -1,0 +1,89 @@
+import {Component, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+
+@Component({
+    selector: 'hc-typeahead-silent-focus-example',
+    templateUrl: './typeahead-silent-focus-example.component.html',
+    styleUrls: ['./typeahead-silent-focus-example.component.scss']
+})
+export class TypeaheadSilentFocusExampleComponent implements OnInit {
+
+    form: FormGroup;
+    filteredData: string[] = [];
+    typeaheadData = [
+        'Alabama',
+        'Alaska',
+        'Arizona',
+        'Arkansas',
+        'California',
+        'Colorado',
+        'Connecticut',
+        'Delaware',
+        'Florida',
+        'Georgia'
+    ];
+
+    filteredData2: string[] = [];
+    typeaheadData2 = [
+        'Alabama',
+        'Alaska',
+        'Arizona',
+        'Arkansas',
+        'California',
+        'Colorado',
+        'Connecticut',
+        'Delaware',
+        'Florida',
+        'Georgia'
+    ];
+
+    constructor(private fb: FormBuilder) {
+    }
+
+    ngOnInit(): void {
+        this.form = this.fb.group({
+            item: ['', Validators.required],
+            item2: ['', Validators.required]
+        });
+    }
+
+    filterData(term) {
+        this.setValue(term);
+        if (term) {
+            this.filteredData = this.typeaheadData.filter(item => item.toLowerCase().indexOf(term.toLowerCase()) > -1);
+        } else {
+            this.filteredData = this.typeaheadData;
+        }
+    }
+
+    optionSelected(item) {
+        this.setValue(item);
+    }
+
+    private setValue(item) {
+        const control = this.form.get('item');
+        if (control) {
+            control.setValue(item);
+        }
+    }
+
+    filterData2(term) {
+        this.setValue2(term);
+        if (term) {
+            this.filteredData2 = this.typeaheadData2.filter(item => item.toLowerCase().indexOf(term.toLowerCase()) > -1);
+        } else {
+            this.filteredData2 = this.typeaheadData2;
+        }
+    }
+
+    optionSelected2(item) {
+        this.setValue2(item);
+    }
+
+    private setValue2(item) {
+        const control = this.form.get('item2');
+        if (control) {
+            control.setValue(item);
+        }
+    }
+}

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.html
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.html
@@ -4,7 +4,7 @@
             <input #input hcInput [formControl]="_searchTerm" (keydown.tab)="_handleTabKey($event)"
                    (keydown.enter)="_stopPropogation($event)" (keydown.arrowup)="_stopPropogation($event)"
                    (keydown.arrowdown)="_stopPropogation($event)" [placeholder]="placeholder" [title]="_value"
-                   autocomplete="off" (blur)="_blurHandler($event)" (focus)="_focusHandler($event)"/>
+                   autocomplete="off" (blur)="_blurHandler($event)" (focus)="_focusHandler($event)" (mousedown)="_clickHandler($event)"/>
             <hc-error style="display: none;">parent is showing error message</hc-error>
         </hc-form-field>
     </form>

--- a/projects/cashmere/src/lib/typeahead/typeahead.component.ts
+++ b/projects/cashmere/src/lib/typeahead/typeahead.component.ts
@@ -49,6 +49,9 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
     public _value = '';
     private _form: NgForm | FormGroupDirective | null;
 
+    // Internal variable used to know if the input received focus due to a click or not
+    private _wasClick = false;
+
     /** Number of characters required before the typehead will begin searching, default 1 */
     @Input()
     minChars: number = 1;
@@ -66,6 +69,14 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
     /** (it does not automatically turn on and off, you need to manually control it), default false */
     @Input()
     showSpinner: boolean = false;
+
+    /** Whether the focus event should emit a valueChange event and show the results. */
+    /** If set to true, then it will not emit the event nor show results until the user modifies the value */
+    /** in the input or the input value is empty. */
+    /** This is necessary to enable a user to be able to tab through the typeahead without clearing its value. */
+    /** Default is true. */
+    @Input()
+    silentFocus: boolean = true;
 
     /** Event emitted after each key stroke in the typeahead box (after minChars requirement has been met) */
     @Output()
@@ -399,9 +410,24 @@ export class TypeaheadComponent extends HcFormControlComponent implements OnInit
         this.blur.emit(event);
     }
 
+    _clickHandler(event) {
+        this._wasClick = true;
+    }
+
     _focusHandler(event) {
-        this._resultPanelHidden = false;
-        this.valueChange.emit('');
+        let shouldEmit = !this.silentFocus;
+
+        if (this._wasClick || this.value === '') {
+            shouldEmit = true;
+        }
+
+        if (shouldEmit) {
+            this._resultPanelHidden = false;
+            this.valueChange.emit('');
+        }
+
+        // reset the clicker tracker
+        this._wasClick = false;
     }
 
     _getHighlightedIndex() {

--- a/src/app/core/document-items.service.ts
+++ b/src/app/core/document-items.service.ts
@@ -273,7 +273,7 @@ const docs: DocItem[] = [
         id: 'typeahead',
         name: 'Typeahead',
         category: 'forms',
-        examples: ['typeahead-overview', 'typeahead-stacked', 'typeahead-highlighting', 'typeahead-highlighting-object', 'typeahead-error', 'typeahead-fetch']
+        examples: ['typeahead-overview', 'typeahead-stacked', 'typeahead-highlighting', 'typeahead-highlighting-object', 'typeahead-error', 'typeahead-fetch', 'typeahead-silent-focus']
     },
     {
         id: 'typeahead-title',


### PR DESCRIPTION
The typeahead component clears the selected item when it receives focus. Added a configuration to
all it to not clear the selected item when tabbed into but it will still clear it and show results
if the value in the input is empty string or if it is clicked. Made the new default to not clear
item.